### PR TITLE
Added separate commands for opening and closing the outline window

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ require('symbols-outline').setup(opts)
 ## Commands
 ```vim
 SymbolsOutline 
+SymbolsOutlineOpen
+SymbolsOutlineClose 
 ```
 ## Keymaps
 ```vim

--- a/lua/symbols-outline.lua
+++ b/lua/symbols-outline.lua
@@ -10,6 +10,10 @@ local M = {}
 local function setup_commands()
     vim.cmd("command! " .. "SymbolsOutline " ..
                 ":lua require'symbols-outline'.toggle_outline()")
+    vim.cmd("command! " .. "SymbolsOutlineOpen " ..
+                ":lua require'symbols-outline'.open_outline()")
+    vim.cmd("command! " .. "SymbolsOutlineClose " ..
+                ":lua require'symbols-outline'.close_outline()")
 end
 
 local function setup_autocmd()
@@ -186,6 +190,19 @@ function M.toggle_outline()
         vim.lsp.buf_request(0, "textDocument/documentSymbol", getParams(),
                             handler)
     else
+        vim.api.nvim_win_close(M.state.outline_win, true)
+    end
+end
+
+function M.open_outline()
+    if M.state.outline_buf == nil then
+        vim.lsp.buf_request(0, "textDocument/documentSymbol", getParams(),
+                            handler)
+    end
+end
+
+function M.close_outline()
+    if M.state.outline_buf ~= nil then
         vim.api.nvim_win_close(M.state.outline_win, true)
     end
 end

--- a/lua/symbols-outline/debug.lua
+++ b/lua/symbols-outline/debug.lua
@@ -13,6 +13,10 @@ end
 function D.setup_commands()
     vim.cmd("command! " .. "DSymbolsOutline " ..
                 ":lua require'symbols-outline'.R('symbols-outline').toggle_outline()")
+    vim.cmd("command! " .. "DSymbolsOutlineOpen " ..
+                ":lua require'symbols-outline'.R('symbols-outline').open_outline()")
+    vim.cmd("command! " .. "DSymbolsOutlineClose " ..
+                ":lua require'symbols-outline'.R('symbols-outline').close_outline()")
 end
 
 return D


### PR DESCRIPTION
Just a small change to add separate commands for opening and closing the outline window. 

This is helpful for working with plugins like [panelmanager.vim](https://github.com/mipmip/panelmanager.vim).