### PR TITLE
Set filetype

### DIFF
--- a/lua/symbols-outline.lua
+++ b/lua/symbols-outline.lua
@@ -163,6 +163,7 @@ local function setup_buffer()
     vim.api.nvim_win_set_option(M.state.outline_win, "number", false)
     vim.api.nvim_win_set_option(M.state.outline_win, "relativenumber", false)
     vim.api.nvim_buf_set_name(M.state.outline_buf, "OUTLINE")
+    vim.api.nvim_buf_set_option(M.state.outline_buf, "filetype", "Outline")
     vim.api.nvim_buf_set_option(M.state.outline_buf, "modifiable", false)
 end
 


### PR DESCRIPTION
Tiny addition to set filetype in addition to buffer name, so that it can be used for conditional user settings. I use it with galaxyline (statusline) `short_line_list` config.