### PR TITLE
Load plugin without having to call anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,65 @@
 # symbols-outline.nvim
-<b> A tree like view for symbols in Neovim using the Language Server Protocol. Supports all your favourite languages.</b>
+
+**A tree like view for symbols in Neovim using the Language Server Protocol.
+Supports all your favourite languages.**
 
 ![demo](https://github.com/simrat39/rust-tools-demos/raw/master/symbols-demo.gif)
 
-# Prerequisites
+### Prerequisites
 
 - `neovim 0.5+` (nightly)
 
-# Installation
+### Installation
 
-using `vim-plug`
+Using `vim-plug`
 
 ```vim
 Plug 'simrat39/symbols-outline.nvim'
 ```
 
-# Setup
+### Configuration
+
+Define a global variable `symbols_outline` as follows:
+
 ```lua
-local opts = {
-    -- whether to highlight the currently hovered symbol
-    -- disable if your cpu usage is higher than you want it
-    -- or you just hate the highlight
-    -- default: true
+-- init.lua
+vim.g.symbols_outline = {
     highlight_hovered_item = true,
-
-    -- whether to show outline guides 
-    -- default: true
     show_guides = true,
+    position = 'right',
 }
-
-require('symbols-outline').setup(opts)
 ```
 
-## Commands
 ```vim
-SymbolsOutline 
-SymbolsOutlineOpen
-SymbolsOutlineClose 
+" init.vim
+let g:symbols_outline = {}
+let g:symbols_outline.highlight_hovered_item = v:true
+let g:symbols_outline.show_guides = v:true
+let g:symbols_outline.position = 'right'
 ```
-## Keymaps
-```vim
-Escape --> Close Outline
-Enter --> GoTo Symbol location in code
-o --> GoTo Symbol location in code but stay in outline window
-Ctrl + Space --> Hover current symbol
-r --> Rename symbol 
-a --> Code Actions
-```
+
+| Property | Description | Type | Default | 
+| --- | -- | -- | -- |
+| highlight_hovered_item | Whether to highlight the currently hovered symbol (high cpu usage) | boolean | true |
+| show_guides | Wether to show outline guides | boolean | true |
+| position | Where to open the split window | 'right' or 'left' | 'right' |
+
+### Commands
+
+| Command                | Description            |
+| ---------------------- | ---------------------- |
+| `:SymbolsOutline`      | Toggle symbols outline |
+| `:SymbolsOutlineOpen`  | Open symbols outline   |
+| `:SymbolsOutlineClose` | Close symbols outline  |
+
+### Keymaps
+
+| Key | Action |
+| -- | -- |
+| Escape | Close outline |
+| Enter | Go to symbol location in code |
+| o | Go to symbol location in code without losing focus |
+| Ctrl+Space | Hover current symbol | 
+| r | Rename symbol |
+| a | Code actions |
+

--- a/plugin/symbols-outline.vim
+++ b/plugin/symbols-outline.vim
@@ -1,0 +1,11 @@
+if exists('g:loaded_symbols_outline')
+    finish
+endif
+let g:loaded_symbols_outline = 1
+
+if exists('g:symbols_outline')
+    call luaeval('require"symbols-outline".setup(_A[1])', [g:symbols_outline])
+else
+    call luaeval('require"symbols-outline".setup()')
+endif
+


### PR DESCRIPTION
### Why?

Currently, you gotta call `lua require('symbols-outline').setup()` somewhere in order for the plugin to load and the commands to be accessible.

### How?

I call the function from `plugin/symbols_outline.vim` file, but to allow user to configure the plugin I read the variable `g:symbols_outline` that can be defined by the user as mentioned in the readme. I took inspiration for that from [nvim-compe](https://github.com/hrsh7th/nvim-compe)