### PR TITLE
feat(config): Add preview keymap trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ vim.g.symbols_outline = {
         goto_location = "<Cr>",
         focus_location = "o",
         hover_symbol = "<C-space>",
+        preview_symbol = "K",
         rename_symbol = "r",
         code_actions = "a",
     },
@@ -108,6 +109,7 @@ vim.g.symbols_outline = {
 | Enter      | Go to symbol location in code                      |
 | o          | Go to symbol location in code without losing focus |
 | Ctrl+Space | Hover current symbol                               |
+| K          | Show current symbol preview                        |
 | r          | Rename symbol                                      |
 | a          | Code actions                                       |
 

--- a/lua/symbols-outline.lua
+++ b/lua/symbols-outline.lua
@@ -195,6 +195,9 @@ local function setup_keymaps(bufnr)
     -- hover symbol
     nmap(config.options.keymaps.hover_symbol,
          ":lua require('symbols-outline.hover').show_hover()<Cr>")
+    -- preview symbol
+    nmap(config.options.keymaps.preview_symbol,
+         ":lua require('symbols-outline.preview').show()<Cr>")
     -- rename symbol
     nmap(config.options.keymaps.rename_symbol,
          ":lua require('symbols-outline.rename').rename()<Cr>")

--- a/lua/symbols-outline/config.lua
+++ b/lua/symbols-outline/config.lua
@@ -16,6 +16,7 @@ local defaults = {
         goto_location = "<Cr>",
         focus_location = "o",
         hover_symbol = "<C-space>",
+        preview_symbol = "K",
         rename_symbol = "r",
         code_actions = "a"
     },


### PR DESCRIPTION
Automatic preview causes an infinite loop for some reason on low end PCs. This exposes an option for manually triggering the preview which can be used as a workaround.