### PR TITLE
chore: adapt lsp request handler for nvim >= 0.5.1

### DIFF
--- a/lua/symbols-outline/code_action.lua
+++ b/lua/symbols-outline/code_action.lua
@@ -1,6 +1,7 @@
 local vim = vim
 
 local main = require('symbols-outline')
+local buf_request = require('symbols-outline.utils.lsp_utils').request
 
 local M = {}
 
@@ -24,7 +25,7 @@ function M.show_code_actions()
 
     local params = get_action_params(node, main.state.code_win)
 
-    vim.lsp.buf_request(params.bufnr, "textDocument/codeAction", params,
+    buf_request(params.bufnr, "textDocument/codeAction", params,
                         vim.lsp.handlers["textDocument/codeAction"])
 end
 

--- a/lua/symbols-outline/hover.lua
+++ b/lua/symbols-outline/hover.lua
@@ -2,6 +2,7 @@ local vim = vim
 
 local main = require('symbols-outline')
 local util = vim.lsp.util
+local buf_request = require('symbols-outline.utils.lsp_utils').request
 
 local M = {}
 
@@ -23,8 +24,8 @@ function M.show_hover()
 
     local hover_params = get_hover_params(node, main.state.code_win)
 
-    vim.lsp.buf_request(hover_params.bufnr, "textDocument/hover", hover_params,
-                        function(_, _, result, _, _, config)
+    buf_request(hover_params.bufnr, "textDocument/hover", hover_params,
+                        function(_, result, _, config)
 
         if not (result and result.contents) then
             -- return { 'No information available' }

--- a/lua/symbols-outline/preview.lua
+++ b/lua/symbols-outline/preview.lua
@@ -1,6 +1,7 @@
 local vim = vim
 local main = require('symbols-outline')
 local config = require('symbols-outline.config')
+local buf_request = require('symbols-outline.utils.lsp_utils').request
 
 local M = {}
 
@@ -103,8 +104,8 @@ local function update_hover()
     if not node then return end
     local params = get_hover_params(node, main.state.code_win)
 
-    vim.lsp.buf_request(params.bufnr, "textDocument/hover", params,
-                        function(err, _, result)
+    buf_request(params.bufnr, "textDocument/hover", params,
+                        function(err, result)
         if err then print(vim.inspect(err)) end
         local markdown_lines = {}
         if result ~= nil then

--- a/lua/symbols-outline/rename.lua
+++ b/lua/symbols-outline/rename.lua
@@ -1,6 +1,7 @@
 local vim = vim
 
 local main = require('symbols-outline')
+local buf_request = require('symbols-outline.utils.lsp_utils').request
 
 local M = {}
 
@@ -26,8 +27,8 @@ function M.rename()
 
     params.newName = new_name
 
-    vim.lsp.buf_request(params.bufnr, "textDocument/rename", params,
-                        function(_, _, result)
+    buf_request(params.bufnr, "textDocument/rename", params,
+                        function(_, result)
         if result ~= nil then
             vim.lsp.util.apply_workspace_edit(result)
         end

--- a/lua/symbols-outline/utils/lsp_utils.lua
+++ b/lua/symbols-outline/utils/lsp_utils.lua
@@ -2,6 +2,31 @@ local vim = vim
 
 local M = {}
 
+-- callback args changed in Neovim 0.5.1/0.6. See:
+-- https://github.com/neovim/neovim/pull/15504
+local function mk_handler(fn)
+  return function(...)
+    local config_or_client_id = select(4, ...)
+    local is_new = type(config_or_client_id) ~= "number"
+    if is_new then
+      fn(...)
+    else
+      local err = select(1, ...)
+      local method = select(2, ...)
+      local result = select(3, ...)
+      local client_id = select(4, ...)
+      local bufnr = select(5, ...)
+      local config = select(6, ...)
+      fn(err, result, { method = method, client_id = client_id, bufnr = bufnr }, config)
+    end
+  end
+end
+
+-- from mfussenegger/nvim-lsp-compl@29a81f3
+function M.request(bufnr, method, params, handler)
+  return vim.lsp.buf_request(bufnr, method, params, mk_handler(handler))
+end
+
 function M.is_buf_attached_to_lsp(bufnr)
     local clients = vim.lsp.buf_get_clients(bufnr or 0)
     return clients ~= nil and #clients > 0


### PR DESCRIPTION
Old handler signature: `function(err, method, result, client_id, bufnr, config)`

New handler signature: `function(err, result, ctx, config)`

Without this change, this plugin is unfortunately broken for any nightly or HEAD users.

You should be able to remove the new functions and use the the original `vim.lsp.request` once 0.5.1 is released.

See https://github.com/neovim/neovim/pull/15504