### PR TITLE
add space after markdown header markup

### DIFF
--- a/lua/symbols-outline/markdown.lua
+++ b/lua/symbols-outline/markdown.lua
@@ -10,7 +10,7 @@ function M.handle_markdown()
     local results = {}
 
     for line, value in ipairs(lines) do
-        if string.find(value, "^#+") then
+        if string.find(value, "^#+ ") then
             if #results > 0 then
                results[#results].selectionRange["end"].line = line - 1
                results[#results].range["end"].line = line - 1


### PR DESCRIPTION
using more strict markdown syntax to avoid some errors resulting from some program behaviors such  rust derive and so on. 