### PR TITLE
feat: added auto_close symbols-outline window functionality for goto

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Supports all your favourite languages.**
 ### Prerequisites
 
 - `neovim 0.5+`
--  Properly configured Neovim LSP client
+- Properly configured Neovim LSP client
 
 ### Installation
 
@@ -33,6 +33,7 @@ vim.g.symbols_outline = {
     auto_preview = true,
     position = 'right',
     width = 25,
+    auto_close = false,
     show_numbers = false,
     show_relative_numbers = false,
     show_symbol_details = true,
@@ -85,6 +86,7 @@ vim.g.symbols_outline = {
 | show_guides            | Whether to show outline guides                                                 | boolean            | true                     |
 | position               | Where to open the split window                                                 | 'right' or 'left'  | 'right'                  |
 | width                  | How big the window is (relative to the current split)                          | int                | 25                       |
+| auto_close             | Whether to automatically close the window after selection                      | boolean            | false                    |
 | auto_preview           | Show a preview of the code on hover                                            | boolean            | true                     |
 | show_numbers           | Shows numbers with the outline                                                 | boolean            | false                    |
 | show_relative_numbers  | Shows relative numbers with the outline                                        | boolean            | false                    |
@@ -105,18 +107,19 @@ vim.g.symbols_outline = {
 
 ### Default keymaps
 
-| Key        | Action                                                             |
-| ---------- | ------------------------------------------------------------------ |
-| Escape     | Close outline                                                      |
-| Enter      | Go to symbol location in code                                      |
-| o          | Go to symbol location in code without losing focus                 |
-| Ctrl+Space | Hover current symbol                                               |
-| K          | Toggles the current symbol preview                                 |
-| r          | Rename symbol                                                      |
-| a          | Code actions                                                       |
-| ?          | Show help message                                                  |
+| Key        | Action                                             |
+| ---------- | -------------------------------------------------- |
+| Escape     | Close outline                                      |
+| Enter      | Go to symbol location in code                      |
+| o          | Go to symbol location in code without losing focus |
+| Ctrl+Space | Hover current symbol                               |
+| K          | Toggles the current symbol preview                 |
+| r          | Rename symbol                                      |
+| a          | Code actions                                       |
+| ?          | Show help message                                  |
 
 ### Highlights
+
 | Highlight               | Purpose                                |
 | ----------------------- | -------------------------------------- |
 | FocusedSymbol           | Highlight of the focused symbol        |

--- a/doc/symbols-outline.txt
+++ b/doc/symbols-outline.txt
@@ -49,6 +49,7 @@ or skip this section entirely if you want to roll with the defaults.
         auto_preview = true,
         position = 'right',
         width = 25,
+        auto_close = false,
         show_numbers = false,
         show_relative_numbers = false,
         show_symbol_details = true,
@@ -131,6 +132,15 @@ width
     Default: 25                                                            ~
 
     Type: int
+
+-----------------------------------------------------------------------------
+auto_close
+
+    Whether to automatically close the window after selection
+
+    Default: false                                                         ~
+
+    Type: boolean
 
 -----------------------------------------------------------------------------
 auto_preview

--- a/lua/symbols-outline.lua
+++ b/lua/symbols-outline.lua
@@ -72,6 +72,7 @@ function M._goto_location(change_focus)
     vim.api.nvim_win_set_cursor(M.state.code_win,
                                 {node.line + 1, node.character})
     if change_focus then vim.fn.win_gotoid(M.state.code_win) end
+    if config.options.auto_close then M.close_outline() end
 end
 
 function M._highlight_current_item(winnr)

--- a/lua/symbols-outline/config.lua
+++ b/lua/symbols-outline/config.lua
@@ -7,6 +7,7 @@ M.defaults = {
     show_guides = true,
     position = 'right',
     width = 25,
+    auto_close = false,
     auto_preview = true,
     show_numbers = false,
     show_relative_numbers = false,


### PR DESCRIPTION
Adds an additional config option for automatically closing the symbols-outline window once a symbol is selected for "goto".