### PR TITLE
feat: add fixed width option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ vim.g.symbols_outline = {
 | highlight_hovered_item | Whether to highlight the currently hovered symbol (high cpu usage)             | boolean            | true                     |
 | show_guides            | Whether to show outline guides                                                 | boolean            | true                     |
 | position               | Where to open the split window                                                 | 'right' or 'left'  | 'right'                  |
-| width                  | How big the window is (relative to the current split)                          | int                | 25                       |
+| relative_width         | Whether width of window is set relative to existing windows                    | boolean            | true                     |
+| width                  | Width of window (as a % or columns based on `relative_width`)                  | int                | 25                       |
 | auto_preview           | Show a preview of the code on hover                                            | boolean            | true                     |
 | show_numbers           | Shows numbers with the outline                                                 | boolean            | false                    |
 | show_relative_numbers  | Shows relative numbers with the outline                                        | boolean            | false                    |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ vim.g.symbols_outline = {
     show_guides = true,
     auto_preview = true,
     position = 'right',
+    relative_width = true,
     width = 25,
     show_numbers = false,
     show_relative_numbers = false,

--- a/doc/symbols-outline.txt
+++ b/doc/symbols-outline.txt
@@ -124,9 +124,20 @@ position
     Type: 'right' or 'left'
 
 -----------------------------------------------------------------------------
+relative_width
+
+    Whether the width of the window is relative to the current split or an
+    absolute width
+
+    Default: true                                                            ~
+
+    Type: boolean
+
+-----------------------------------------------------------------------------
 width
 
-    How big the window is (relative to the current split)
+    Width of the window as a percentage of the current split
+    (`relative_width `= true) or as number of columns (`relative_width `= false)
 
     Default: 25                                                            ~
 

--- a/lua/symbols-outline/config.lua
+++ b/lua/symbols-outline/config.lua
@@ -71,7 +71,6 @@ end
 
 function M.get_window_width()
   if M.options.relative_width then
-    -- local current_win_width = vim.api.nvim_win_get_width(0)
     return math.ceil(vim.api.nvim_win_get_width(0) * (M.options.width / 100))
   else
     return M.options.width

--- a/lua/symbols-outline/config.lua
+++ b/lua/symbols-outline/config.lua
@@ -6,6 +6,7 @@ M.defaults = {
     highlight_hovered_item = true,
     show_guides = true,
     position = 'right',
+    relative_width = true,
     width = 25,
     auto_preview = true,
     show_numbers = false,
@@ -68,7 +69,15 @@ function M.get_position_navigation_direction()
     end
 end
 
-function M.get_width_percentage() return M.options.width / 100 end
+function M.get_window_width()
+  if M.options.relative_width then
+    -- local current_win_width = vim.api.nvim_win_get_width(0)
+    return math.ceil(vim.api.nvim_win_get_width(0) * (M.options.width / 100))
+  else
+    return M.options.width
+  end
+end
+
 
 function M.get_split_command()
     if M.options.position == 'left' then

--- a/lua/symbols-outline/view.lua
+++ b/lua/symbols-outline/view.lua
@@ -11,15 +11,10 @@ function M.setup_view()
 
     -- delete buffer when window is closed / buffer is hidden
     vim.api.nvim_buf_set_option(bufnr, "bufhidden", "delete")
-
-    local current_win = vim.api.nvim_get_current_win()
-    local current_win_width = vim.api.nvim_win_get_width(current_win)
-
     -- create a split
     vim.cmd(config.get_split_command())
     -- resize to a % of the current window size
-    vim.cmd("vertical resize " ..
-                math.ceil(current_win_width * config.get_width_percentage()))
+    vim.cmd("vertical resize " .. config.get_window_width())
 
     -- get current (outline) window and attach our buffer to it
     local winnr = vim.api.nvim_get_current_win()


### PR DESCRIPTION
closes #79

My preference would've been to not add a `relative_width` option and base the width on whether the `width` option is a float or int. So eg. `width = 0.25` would make the window 25% of the current split but `width = 25` would make the window 25 columns wide. I believe this is how nvim-telescope handles widths. But I decided against this since I imagine this will mess up most people config for this plugin.