### PR TITLE
add show_icon option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ vim.g.symbols_outline = {
     show_numbers = false,
     show_relative_numbers = false,
     show_symbol_details = true,
+    show_icon = true,
     preview_bg_highlight = 'Pmenu',
     keymaps = { -- These keymaps can be a string or a table for multiple keys
         close = {"<Esc>", "q"},
@@ -91,6 +92,7 @@ vim.g.symbols_outline = {
 | show_numbers           | Shows numbers with the outline                                                 | boolean            | false                    |
 | show_relative_numbers  | Shows relative numbers with the outline                                        | boolean            | false                    |
 | show_symbol_details    | Shows extra details with the symbols (lsp dependent)                           | boolean            | true                     |
+| show_icon              | Show icon                                                           | boolean            | true                     |
 | preview_bg_highlight   | Background color of the preview window                                         | string             | Pmenu                    |
 | keymaps                | Which keys do what                                                             | table (dictionary) | [here](#default-keymaps) |
 | symbols                | Icon and highlight config for symbol icons                                     | table (dictionary) | scroll up                |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ vim.g.symbols_outline = {
 | show_numbers           | Shows numbers with the outline                                                 | boolean            | false                    |
 | show_relative_numbers  | Shows relative numbers with the outline                                        | boolean            | false                    |
 | show_symbol_details    | Shows extra details with the symbols (lsp dependent)                           | boolean            | true                     |
-| show_icon              | Show icon                                                           | boolean            | true                     |
+| show_icon              | Show icon                                                                      | boolean            | true                     |
 | preview_bg_highlight   | Background color of the preview window                                         | string             | Pmenu                    |
 | keymaps                | Which keys do what                                                             | table (dictionary) | [here](#default-keymaps) |
 | symbols                | Icon and highlight config for symbol icons                                     | table (dictionary) | scroll up                |

--- a/doc/symbols-outline.txt
+++ b/doc/symbols-outline.txt
@@ -52,6 +52,7 @@ or skip this section entirely if you want to roll with the defaults.
         show_numbers = false,
         show_relative_numbers = false,
         show_symbol_details = true,
+	show_icon = true,
         preview_bg_highlight = 'Pmenu',
         -- These keymaps can be a string or a table for multiple keys
         keymaps = {
@@ -174,6 +175,15 @@ show_relative_numbers
 show_symbol_details
 
     Shows extra details with the symbols (lsp dependent)
+
+    Default: true                                                          ~
+
+    Type: boolean
+
+-----------------------------------------------------------------------------
+show_icon
+
+    Shows icon
 
     Default: true                                                          ~
 

--- a/lua/symbols-outline/config.lua
+++ b/lua/symbols-outline/config.lua
@@ -12,6 +12,7 @@ M.defaults = {
     show_numbers = false,
     show_relative_numbers = false,
     show_symbol_details = true,
+    show_icon = true,
     preview_bg_highlight = 'Pmenu',
     keymaps = { -- These keymaps can be a string or a table for multiple keys
         close = {"<Esc>", "q"},

--- a/lua/symbols-outline/parser.lua
+++ b/lua/symbols-outline/parser.lua
@@ -194,8 +194,9 @@ function M.get_lines(flattened_outline_items)
             table.insert(final_prefix, " ")
         end
 
-        table.insert(lines, table_to_str(final_prefix) .. value.icon .. " " ..
-                         value.name)
+        local icon = ""
+        if config.show_icon then icon = value.icon .. " " end
+        table.insert(lines, table_to_str(final_prefix) .. icon .. value.name)
     end
     return lines
 end


### PR DESCRIPTION
When the nerd font cannot be used, the icon cannot be displayed normally