### PR TITLE
Calculate outline width relative to number of columns on screen

### DIFF
--- a/lua/symbols-outline/config.lua
+++ b/lua/symbols-outline/config.lua
@@ -72,7 +72,7 @@ end
 
 function M.get_window_width()
   if M.options.relative_width then
-    return math.ceil(vim.api.nvim_win_get_width(0) * (M.options.width / 100))
+    return math.ceil(vim.o.columns * (M.options.width / 100))
   else
     return M.options.width
   end


### PR DESCRIPTION
I noticed that both my [kyazdani42/nvim-tree.lua](https://github.com/kyazdani42/nvim-tree.lua) and `symbols-outline.nvim` configs defined the width as 25% (using relative width) but the `nvim-tree` split was wider as shown below:

![image](https://user-images.githubusercontent.com/34950778/147368202-551e75d0-a3ab-4bf8-a41c-afa3cb1eed0c.png)

![image](https://user-images.githubusercontent.com/34950778/147368237-d79f222d-1e05-4e72-956c-591c522535a8.png)

You can see that the outline split looks about half the width of the `nvim-tree` split even though they're both supposed to be 25%. This is because of two things:

1. The width to resize the split to is calculated after the split has been created: https://github.com/simrat39/symbols-outline.nvim/blob/034792838579c4b1515c8a5037aba58ecd1d9b35/lua/symbols-outline/view.lua#L14-L17
2. The width is calculated relative to the width of the current window: https://github.com/simrat39/symbols-outline.nvim/blob/034792838579c4b1515c8a5037aba58ecd1d9b35/lua/symbols-outline/config.lua#L73-L79

This means that in the case shown in the screenshots:
* we create the split
* we resize the split relative to the width of this split

You could fix 1. by instead: 
* calculating the desired split width from the current window
* creating the split
* resizing the split to the previously calculated width

but then you would still have the outline being created with different widths depending on the width of the window that it was opened from which seems unintuitive.

This PR changes it so that the width is always calculated relative to the `columns` vim option which only changes as you resize the actual terminal window, making the outline always open with the same width given the same terminal window size.

With this change, my outline now opens like this (even with two vertical splits open):
![image](https://user-images.githubusercontent.com/34950778/147368777-b54afbb2-80b4-4769-a542-42c4de1eac94.png)
