### PR TITLE
Floating window 

### DIFF
--- a/lua/symbols-outline/config.lua
+++ b/lua/symbols-outline/config.lua
@@ -6,6 +6,13 @@ M.defaults = {
     highlight_hovered_item = true,
     show_guides = true,
     position = 'right',
+    floating = {
+        enabled = false,
+        width = 30,
+        height = 15,
+        row = 0.5,
+        col = 0.5,
+    },
     relative_width = true,
     width = 25,
     auto_close = false,

--- a/lua/symbols-outline/view.lua
+++ b/lua/symbols-outline/view.lua
@@ -29,6 +29,18 @@ function M.setup_view()
     vim.api.nvim_buf_set_option(bufnr, "filetype", "Outline")
     vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
 
+    if config.options.floating.enabled == true then
+        local opts = {
+            height = config.options.floating.height,
+            width = config.options.floating.width,
+            row = config.options.floating.row,
+            col = config.options.floating.col,
+            border = "single",
+            relative = "editor",
+        }
+        vim.api.nvim_win_set_config(winnr, opts)
+    end
+
     if config.options.show_numbers or config.options.show_relative_numbers then
         vim.api.nvim_win_set_option(winnr, "nu", true)
     end


### PR DESCRIPTION
This PR implements an option to open SymbolsOutline in a floating window as mentioned in #100.
At the moment, I have a basic proof of concept that seems to work well, however, it's far from done, and it should also allow centering the window (similarly to how telescope.nvim behaves). 