### PR TITLE
Highlight icons using highlight regions rather than matching rules

### DIFF
--- a/lua/symbols-outline/parser.lua
+++ b/lua/symbols-outline/parser.lua
@@ -161,6 +161,7 @@ end
 
 function M.get_lines(flattened_outline_items)
     local lines = {}
+    local hl_info = {}
     for _, value in ipairs(flattened_outline_items) do
         local line = str_to_table(string.rep(" ", value.depth))
 
@@ -194,10 +195,15 @@ function M.get_lines(flattened_outline_items)
             table.insert(final_prefix, " ")
         end
 
-        table.insert(lines, table_to_str(final_prefix) .. value.icon .. " " ..
+        local string_prefix = table_to_str(final_prefix)
+        local hl_start = #string_prefix + 1
+        local hl_end = #string_prefix + #value.icon
+        table.insert(lines, string_prefix .. value.icon .. " " ..
                          value.name)
+        hl_type = config.options.symbols[symbols.kinds[value.kind]].hl
+        table.insert(hl_info, {hl_start, hl_end, hl_type})
     end
-    return lines
+    return lines, hl_info
 end
 
 function M.get_details(flattened_outline_items)

--- a/lua/symbols-outline/parser.lua
+++ b/lua/symbols-outline/parser.lua
@@ -196,7 +196,7 @@ function M.get_lines(flattened_outline_items)
         end
 
         local string_prefix = table_to_str(final_prefix)
-        local hl_start = #string_prefix + 1
+        local hl_start = #string_prefix
         local hl_end = #string_prefix + #value.icon
         table.insert(lines, string_prefix .. value.icon .. " " ..
                          value.name)

--- a/lua/symbols-outline/ui.lua
+++ b/lua/symbols-outline/ui.lua
@@ -52,12 +52,6 @@ function M.setup_highlights()
     highlight_text("markers_horizontal", M.markers.horizontal,
                    "SymbolsOutlineConnector")
     highlight_text("markers_bottom", M.markers.bottom, "SymbolsOutlineConnector")
-
-    for _, value in ipairs(symbol_kinds) do
-        local symbol = symbols[value]
-        highlight_text(value, symbol.icon, symbol.hl)
-    end
-
 end
 
 return M

--- a/lua/symbols-outline/writer.lua
+++ b/lua/symbols-outline/writer.lua
@@ -24,7 +24,7 @@ end
 function M.add_highlights(bufnr, hl_info)
     for line, line_hl in ipairs(hl_info) do
         hl_start, hl_end, hl_type = unpack(line_hl)
-        vim.api.nvim_buf_add_highlight(bufnr, hlns, hl_type, line - 1, hl_start - 1, hl_end)
+        vim.api.nvim_buf_add_highlight(bufnr, hlns, hl_type, line - 1, hl_start, hl_end)
     end
 end
 


### PR DESCRIPTION
Fixes #78.

This follows the approach outlined in #78 to highlight icons using highlight regions declared with `nvim_buf_add_highlight` rather than regular expression matching.  This seems to avoid the problem of icon characters accidentally getting highlighted when they show up outside of the icon.