### PR TITLE
config: make border style configurable

### DIFF
--- a/lua/symbols-outline/config.lua
+++ b/lua/symbols-outline/config.lua
@@ -6,6 +6,7 @@ M.defaults = {
     highlight_hovered_item = true,
     show_guides = true,
     position = 'right',
+    border = 'single',
     relative_width = true,
     width = 25,
     auto_close = false,

--- a/lua/symbols-outline/preview.lua
+++ b/lua/symbols-outline/preview.lua
@@ -170,7 +170,7 @@ local function show_preview()
 			bufpos = { 0, 0 },
 			row = offsets[1],
 			col = offsets[2],
-			border = "single",
+			border = config.options.border,
 		})
 		setup_preview_buf()
 	else
@@ -196,7 +196,7 @@ local function show_hover()
 			bufpos = { 0, 0 },
 			row = offsets[1] + height + 2,
 			col = offsets[2],
-			border = "single",
+			border = config.options.border,
 		})
 		setup_hover_buf()
 	else


### PR DESCRIPTION
This PR creates a variable `border` to configure the border style of the preview/hover window.