### PR TITLE
check if code_win is nill

### DIFF
--- a/lua/symbols-outline/preview.lua
+++ b/lua/symbols-outline/preview.lua
@@ -18,6 +18,9 @@ local function is_current_win_outline()
 end
 
 local function has_code_win()
+	if main.state.code_win == nil then
+		return false
+	end
 	local isWinValid = vim.api.nvim_win_is_valid(main.state.code_win)
 	if not isWinValid then
 		return false


### PR DESCRIPTION
Every time a window opens or closes before :SymbolsOutline (like packer.nvim or telescope) I getting this error.
This change works for me

Error detected while processing WinEnter Autocommands for "*":
E5108: Error executing lua ...art/symbols-outline.nvim/lua/symbols-outline/preview.lua:24: Expected Lua number
stack traceback:
        [C]: in function 'nvim_win_is_valid'
        ...art/symbols-outline.nvim/lua/symbols-outline/preview.lua:24: in function 'has_code_win'
        ...art/symbols-outline.nvim/lua/symbols-outline/preview.lua:221: in function 'close'
        [string ":lua"]:1: in main chunk
        [C]: in function 'resume'
        ...im/site/pack/packer/opt/packer.nvim/lua/packer/async.lua:12: in function <...im/site/pack/packer/opt/packer.nvim/lua/packer/async.lua:11>

E5108: Error executing lua Vim(lua):E5108: Error executing lua ...art/symbols-outline.nvim/lua/symbols-outline/preview.lua:24: Expected Lua number
stack traceback:
        [C]: in function 'nvim_win_is_valid'
        ...art/symbols-outline.nvim/lua/symbols-outline/preview.lua:24: in function 'has_code_win'
        ...art/symbols-outline.nvim/lua/symbols-outline/preview.lua:221: in function 'close'
        [string ":lua"]:1: in main chunk
        [C]: in function 'execute'
        .../site/pack/packer/opt/packer.nvim/lua/packer/display.lua:879: in function 'quit'
        [string ":lua"]:1: in main chunk
stack traceback:
        [C]: in function 'execute'
        .../site/pack/packer/opt/packer.nvim/lua/packer/display.lua:879: in function 'quit'
        [string ":lua"]:1: in main chunk