### PR TITLE
Feat: transparent windows using `winblend`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ vim.g.symbols_outline = {
 | show_relative_numbers  | Shows relative numbers with the outline                                        | boolean            | false                    |
 | show_symbol_details    | Shows extra details with the symbols (lsp dependent)                           | boolean            | true                     |
 | preview_bg_highlight   | Background color of the preview window                                         | string             | Pmenu                    |
+| winblend               | Pseudo-transparency of the preview window                                      | int                | 0                        |
 | keymaps                | Which keys do what                                                             | table (dictionary) | [here](#default-keymaps) |
 | symbols                | Icon and highlight config for symbol icons                                     | table (dictionary) | scroll up                |
 | lsp_blacklist          | Which lsp clients to ignore                                                    | table (array)      | {}                       |

--- a/doc/symbols-outline.txt
+++ b/doc/symbols-outline.txt
@@ -199,6 +199,16 @@ preview_bg_highlight
     Type: string
 
 -----------------------------------------------------------------------------
+winblend
+
+    Pseudo-transparency of the preview window (value between `0` and `100`)
+    See `:h winblend`
+
+    Default: 0
+
+    Type: int
+
+-----------------------------------------------------------------------------
 keymaps
 
     Which keys do what

--- a/lua/symbols-outline/config.lua
+++ b/lua/symbols-outline/config.lua
@@ -15,6 +15,7 @@ M.defaults = {
   show_relative_numbers = false,
   show_symbol_details = true,
   preview_bg_highlight = 'Pmenu',
+  winblend = 0,
   keymaps = { -- These keymaps can be a string or a table for multiple keys
     close = { '<Esc>', 'q' },
     goto_location = '<Cr>',

--- a/lua/symbols-outline/preview.lua
+++ b/lua/symbols-outline/preview.lua
@@ -151,6 +151,9 @@ local function set_bg_hl()
   local winhi = 'Normal:' .. config.options.preview_bg_highlight
   vim.api.nvim_win_set_option(state.preview_win, 'winhighlight', winhi)
   vim.api.nvim_win_set_option(state.hover_win, 'winhighlight', winhi)
+  local winblend = config.options.winblend
+  vim.api.nvim_win_set_option(state.preview_win, 'winblend', winblend)
+  vim.api.nvim_win_set_option(state.hover_win, 'winblend', winblend)
 end
 
 local function show_preview()


### PR DESCRIPTION
Allows users to customise the transparency of the floating preview windows.