### PR TITLE
Do not close outline when focus_location occurs

### DIFF
--- a/lua/symbols-outline.lua
+++ b/lua/symbols-outline.lua
@@ -67,9 +67,9 @@ function M._goto_location(change_focus)
   vim.api.nvim_win_set_cursor(M.state.code_win, { node.line + 1, node.character })
   if change_focus then
     vim.fn.win_gotoid(M.state.code_win)
-  end
-  if config.options.auto_close then
-    M.close_outline()
+    if config.options.auto_close then
+      M.close_outline()
+    end
   end
 end
 


### PR DESCRIPTION
When auto_close is set to false, this patch does nothing.
However, when auto_close is set to true now the outline only closes when
the goto_location action is taken.  The action focus_location still
keeps the outline open.