### PR TITLE
feat: Make markers configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ vim.g.symbols_outline = {
         code_actions = "a",
     },
     lsp_blacklist = {},
+    markers = {
+      bottom = '└',
+      middle = '├',
+      vertical = '│',
+      horizontal = '─',
+    },
     symbol_blacklist = {},
     symbols = {
         File = {icon = "", hl = "TSURI"},
@@ -99,6 +105,7 @@ vim.g.symbols_outline = {
 | symbols                | Icon and highlight config for symbol icons                                     | table (dictionary) | scroll up                |
 | lsp_blacklist          | Which lsp clients to ignore                                                    | table (array)      | {}                       |
 | symbol_blacklist       | Which symbols to ignore ([possible values](./lua/symbols-outline/symbols.lua)) | table (array)      | {}                       |
+| markers                | Icon config for markers                                                        | table (dictionary) | scroll up                |
 
 ### Commands
 

--- a/lua/symbols-outline/config.lua
+++ b/lua/symbols-outline/config.lua
@@ -27,6 +27,12 @@ M.defaults = {
     show_help = '?',
   },
   lsp_blacklist = {},
+  markers = {
+    bottom = '└',
+    middle = '├',
+    vertical = '│',
+    horizontal = '─',
+  },
   symbol_blacklist = {},
   symbols = {
     File = { icon = '', hl = 'TSURI' },

--- a/lua/symbols-outline/ui.lua
+++ b/lua/symbols-outline/ui.lua
@@ -3,13 +3,6 @@ local config = require 'symbols-outline.config'
 local symbol_kinds = require('symbols-outline.symbols').kinds
 local M = {}
 
-M.markers = {
-  bottom = '└',
-  middle = '├',
-  vertical = '│',
-  horizontal = '─',
-}
-
 M.hovered_hl_ns = vim.api.nvim_create_namespace 'hovered_item'
 
 function M.clear_hover_highlight(bufnr)
@@ -45,10 +38,10 @@ function M.setup_highlights()
   local symbols = config.options.symbols
 
   -- markers
-  highlight_text('marker_middle', M.markers.middle, 'SymbolsOutlineConnector')
-  highlight_text('marker_vertical', M.markers.vertical, 'SymbolsOutlineConnector')
-  highlight_text('markers_horizontal', M.markers.horizontal, 'SymbolsOutlineConnector')
-  highlight_text('markers_bottom', M.markers.bottom, 'SymbolsOutlineConnector')
+  highlight_text('marker_middle', config.markers.middle, 'SymbolsOutlineConnector')
+  highlight_text('marker_vertical', config.markers.vertical, 'SymbolsOutlineConnector')
+  highlight_text('markers_horizontal', config.markers.horizontal, 'SymbolsOutlineConnector')
+  highlight_text('markers_bottom', config.markers.bottom, 'SymbolsOutlineConnector')
 end
 
 return M


### PR DESCRIPTION
<img width="109" alt="Screen Shot 2022-06-25 at 2 19 55 pm" src="https://user-images.githubusercontent.com/1306029/175757776-9e405240-749a-42cf-a17e-c29cc5ad9278.png">

The default markers looks a bit off for me (maybe due to the font family i am using), yet it would be nice if this is configurable