### PR TITLE
Require explicit setup for autocmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ want to roll with the defaults.
 
 ```lua
 -- init.lua
-vim.g.symbols_outline = {
+require("symbols-outline").setup({
     highlight_hovered_item = true,
     show_guides = true,
     auto_preview = true,
@@ -78,7 +78,7 @@ vim.g.symbols_outline = {
         Operator = {icon = "+", hl = "TSOperator"},
         TypeParameter = {icon = "𝙏", hl = "TSParameter"}
     }
-}
+})
 ```
 
 | Property               | Description                                                                    | Type               | Default                  |

--- a/lua/symbols-outline.lua
+++ b/lua/symbols-outline.lua
@@ -14,6 +14,20 @@ local function setup_global_autocmd()
   if config.options.highlight_hovered_item then
     vim.cmd "au CursorHold * :lua require('symbols-outline')._highlight_current_item()"
   end
+
+  vim.api.nvim_create_autocmd({ 'InsertLeave', 'WinEnter', 'BufEnter', 'BufWinEnter', 'TabEnter', 'BufWritePost' }, {
+    pattern = '*',
+    callback = function()
+      M._refresh()
+    end,
+  })
+
+  vim.api.nvim_create_autocmd({ 'WinEnter' }, {
+    pattern = '*',
+    callback = function()
+      M.preview.close()
+    end,
+  })
 end
 
 local function setup_buffer_autocmd()

--- a/plugin/symbols-outline.vim
+++ b/plugin/symbols-outline.vim
@@ -3,15 +3,6 @@ if exists('g:loaded_symbols_outline')
 endif
 let g:loaded_symbols_outline = 1
 
-if exists('g:symbols_outline')
-    call luaeval('require"symbols-outline".setup(_A[1])', [g:symbols_outline])
-else
-    call luaeval('require"symbols-outline".setup()')
-endif
-
 command! SymbolsOutline :lua require'symbols-outline'.toggle_outline()
 command! SymbolsOutlineOpen :lua require'symbols-outline'.open_outline()
 command! SymbolsOutlineClose :lua require'symbols-outline'.close_outline()
-
-au InsertLeave,WinEnter,BufEnter,BufWinEnter,TabEnter,BufWritePost * :lua require('symbols-outline')._refresh()
-au WinEnter * lua require'symbols-outline.preview'.close()


### PR DESCRIPTION
Currently, some `autocmd` were set up via the `setup()` call, while
others were done implicitly when the module was found.

Move all autocmds behind `setup()`. This makes it possible to
temporarily disable the plugin by just removing the call to `setup()`
from one's configuration.

See: https://github.com/simrat39/symbols-outline.nvim/issues/145