### PR TITLE
Make nvim-treesitter.parsers in jsx provider optional

### DIFF
--- a/lua/symbols-outline/providers/jsx.lua
+++ b/lua/symbols-outline/providers/jsx.lua
@@ -1,14 +1,13 @@
 local M = {}
 
-local parsers = require("nvim-treesitter.parsers")
-
 local SYMBOL_COMPONENT = 27
 local SYMBOL_FRAGMENT = 28
 
 function M.should_use_provider(bufnr)
  local ft = vim.api.nvim_buf_get_option(bufnr, 'ft')
+ local status, _ = pcall(require, "nvim-treesitter.parsers")
 
- return string.match(ft, 'typescriptreact') or string.match(ft, 'javascriptreact')
+ return status and string.match(ft, 'typescriptreact') or string.match(ft, 'javascriptreact')
 end
 
 function M.hover_info(_, _, on_info)
@@ -100,6 +99,7 @@ end
 function M.request_symbols(on_symbols)
   local bufnr = 0
 
+  local parsers = require("nvim-treesitter.parsers")
   local parser = parsers.get_parser(bufnr)
   local root = parser:parse()[1]:root()
 


### PR DESCRIPTION
- Move require call to local function.
- Test if nvim-treesitter.parsers is installed when running
  M.should_use_provider.