### PR TITLE
fix: plugin crashes when SymbolOutlineClose used

### DIFF
--- a/lua/symbols-outline/view.lua
+++ b/lua/symbols-outline/view.lua
@@ -50,9 +50,11 @@ function View:setup_view()
 end
 
 function View:close()
-  vim.api.nvim_win_close(self.winnr, true)
-  self.winnr = nil
-  self.bufnr = nil
+  if self.winnr then
+    vim.api.nvim_win_close(self.winnr, true)
+    self.winnr = nil
+    self.bufnr = nil
+  end
 end
 
 function View:is_open()


### PR DESCRIPTION
if SymbolOutline is not already open