### PR TITLE
Fix some options

### DIFF
--- a/lua/symbols-outline/view.lua
+++ b/lua/symbols-outline/view.lua
@@ -23,6 +23,7 @@ function View:setup_view()
   vim.api.nvim_win_set_buf(self.winnr, self.bufnr)
 
   -- window stuff
+  vim.api.nvim_win_set_option(self.winnr, 'spell', false)
   vim.api.nvim_win_set_option(self.winnr, 'signcolumn', 'no')
   vim.api.nvim_win_set_option(self.winnr, 'number', false)
   vim.api.nvim_win_set_option(self.winnr, 'relativenumber', false)

--- a/lua/symbols-outline/view.lua
+++ b/lua/symbols-outline/view.lua
@@ -23,6 +23,7 @@ function View:setup_view()
   vim.api.nvim_win_set_buf(self.winnr, self.bufnr)
 
   -- window stuff
+  vim.api.nvim_win_set_option(self.winnr, 'signcolumn', 'no')
   vim.api.nvim_win_set_option(self.winnr, 'number', false)
   vim.api.nvim_win_set_option(self.winnr, 'relativenumber', false)
   vim.api.nvim_win_set_option(self.winnr, 'winfixwidth', true)


### PR DESCRIPTION
Currently, if some settings are set globally, it results in wasted space or added noise in the side window that contains the outline.

To fix this, these patches set the following options:
- set signcolumn to 'no'
- set spell to false
