### PR TITLE
fix(parser.lua): indexing into a list returns nil

### DIFF
--- a/lua/symbols-outline/parser.lua
+++ b/lua/symbols-outline/parser.lua
@@ -251,7 +251,7 @@ function M.get_lines(flattened_outline_items)
 
     local hl_start = #string_prefix
     local hl_end = #string_prefix + #node.icon
-    local hl_type = config.options.symbols[symbols.kinds[node.kind]].hl
+    local hl_type = config.options.symbols[node.kind].hl
     table.insert(hl_info, { node_line, hl_start, hl_end, hl_type })
 
     node.prefix_length = #string_prefix + #node.icon + 1


### PR DESCRIPTION
Then an attempt at indexing nil results in no outline. Unclear if this problem was introduced in 094334c1a8b7e308f83aa8d526fdfd68a1b728f4 when the highlighting was reworked or in 3e9e019b03854b6ee1bc3bee0baee08d30ed4c94 when options were introduced. Probably a combination of the two.

Fixes #77 #131 #164 #176