### PR TITLE
fix(coc.lua): no hierarchy when using coc.nvim

### DIFF
--- a/lua/symbols-outline/providers/coc.lua
+++ b/lua/symbols-outline/providers/coc.lua
@@ -23,12 +23,71 @@ function M.hover_info(_, _, on_info)
   })
 end
 
+---@param result table
+local function convert_symbols(result)
+    local s = {}
+    local kinds_index = {}
+    -- create a inverse indexing of symbols.kind
+    local symbols = require("symbols-outline.symbols")
+    for k, v in pairs(symbols.kinds) do
+        kinds_index[v] = k
+    end
+    -- rebuild coc.nvim symbol list hierarchy according to the 'level' key
+    for _, value in pairs(result) do
+        value.children = {}
+        value.kind = kinds_index[value.kind]
+        if #s == 0 then
+            table.insert(s, value)
+            goto continue
+        end
+        if value.level == s[#s].level then
+            if value.level == 0 then
+                table.insert(s, value)
+                goto continue
+            end
+            local tmp = s[#s]
+            table.remove(s)
+            table.insert(s[#s].children, tmp)
+            table.insert(s, value)
+        elseif value.level == s[#s].level + 1 then
+            table.insert(s[#s].children, value)
+        elseif value.level == s[#s].level + 2 then
+            local tmp = s[#s].children[#(s[#s].children)]
+            table.remove(s[#s].children)
+            table.insert(s, tmp)
+            table.insert(s[#s].children, value)
+        elseif value.level < s[#s].level then
+            while value.level < s[#s].level do
+                local tmp = s[#s]
+                table.remove(s)
+                table.insert(s[#s].children, tmp)
+            end
+            if s[#s].level ~= 0 then
+                local tmp = s[#s]
+                table.remove(s)
+                table.insert(s[#s].children, tmp)
+                table.insert(s, value)
+            else
+                table.insert(s, value)
+            end
+        end
+        ::continue::
+    end
+    local top = s[#s]
+    while top.level ~= 0 do
+        table.remove(s)
+        table.insert(s[#s].children, top)
+        top = s[#s]
+    end
+    return s
+end
+
 ---@param on_symbols function
 function M.request_symbols(on_symbols)
   vim.fn.call('CocActionAsync', {
     'documentSymbols',
     function(_, symbols)
-      on_symbols { [1000000] = { result = symbols } }
+      on_symbols { [1000000] = { result = convert_symbols(symbols) } }
     end,
   })
 end


### PR DESCRIPTION
I get the output symbol lists of coc.nvim by using `CocAction('documentSymbols')` and find that the hierarchy of coc symbol lists can be rebuilt using the 'level' key. The output can be simplified as follows (from coc-pyright):

```json
[
    {
        "lnum": 12,
        "col": 1,
        "range": {
            "end": {
                "character": 7,
                "line": 11
            },
            "start": {
                "character": 0,
                "line": 11
            }
        },
        "selectionRange": {
            "end": {
                "character": 7,
                "line": 11
            },
            "start": {
                "character": 0,
                "line": 11
            }
        },
        "level": 0,
        "kind": "Variable",
        "text": "__all__"
    },
    {
        "lnum": 15,
        "col": 7,
        "range": {
            "end": {
                "character": 65,
                "line": 20
            },
            "start": {
                "character": 0,
                "line": 14
            }
        },
        "selectionRange": {
            "end": {
                "character": 18,
                "line": 14
            },
            "start": {
                "character": 6,
                "line": 14
            }
        },
        "level": 0,
        "kind": "Class",
        "text": "BaseProvider"
    },
    {
        "lnum": 20,
        "col": 9,
        "range": {
            "end": {
                "character": 65,
                "line": 20
            },
            "start": {
                "character": 4,
                "line": 18
            }
        },
        "selectionRange": {
            "end": {
                "character": 14,
                "line": 19
            },
            "start": {
                "character": 8,
                "line": 19
            }
        },
        "level": 1,
        "kind": "Method",
        "text": "render"
    }
]
```

I believe that the order of symbols have been sorted by coc so my PR code doesn't contain any code for symbol sort.

It hasn't been fully tested using other languages. If anyone can test the code, I would appreciate. Anyway, it works fine for me XD.
