### PR TITLE
Distinguish between public and private function display in Elixir

### DIFF
--- a/lua/symbols-outline/parser.lua
+++ b/lua/symbols-outline/parser.lua
@@ -42,7 +42,7 @@ local function parse_result(result, depth, hierarchy, parent)
         range = value.location.range
       end
 
-      local kind = starts_with(value.name, 'defp ') and 6 or value.kind
+      local kind = starts_with(value.name or '', 'defp ') and 6 or value.kind
 
       local node = {
         deprecated = value.deprecated,

--- a/lua/symbols-outline/parser.lua
+++ b/lua/symbols-outline/parser.lua
@@ -6,6 +6,10 @@ local folding = require 'symbols-outline.folding'
 
 local M = {}
 
+local function starts_with(str, start)
+  return str:sub(1, #start) == start
+end
+
 ---Parses result from LSP into a table of symbols
 ---@param result table The result from a language server.
 ---@param depth number? The current depth of the symbol in the hierarchy.
@@ -38,10 +42,12 @@ local function parse_result(result, depth, hierarchy, parent)
         range = value.location.range
       end
 
+      local kind = starts_with(value.name, 'defp ') and 6 or value.kind
+
       local node = {
         deprecated = value.deprecated,
-        kind = value.kind,
-        icon = symbols.icon_from_kind(value.kind),
+        kind = kind,
+        icon = symbols.icon_from_kind(kind),
         name = value.name or value.text,
         detail = value.detail,
         line = selectionRange.start.line,


### PR DESCRIPTION
Elixir always returns the function kind, both private and private functions, but their names are not the same.

https://github.com/elixir-lsp/elixir-ls/blob/master/apps/language_server/test/providers/document_symbols_test.exs#L79

I know this is less scalable, so if there is a better way, I hope you guys can give me some direction.

But in general, it works well, and I think it's important to distinguish between public and private functions because we tend to care more about public functions, while private functions contain more implementation details.

<img width="506" alt="image" src="https://user-images.githubusercontent.com/12830256/197780649-db901007-3c5e-448b-afff-ca3750319426.png">
