### PR TITLE
Make close_outline idempotent

### DIFF
--- a/lua/symbols-outline.lua
+++ b/lua/symbols-outline.lua
@@ -318,7 +318,9 @@ function M.open_outline()
 end
 
 function M.close_outline()
-  M.view:close()
+  if M.view:is_open() then
+    M.view:close()
+  end
 end
 
 function M.setup(opts)


### PR DESCRIPTION
`open_outline` currently does nothing if the outline is already open, but `close_outline` raises an error if it's already closed.  This makes it more difficult to ensure the outline is closed from scripts.

This makes the behavior of the two functions symmetrical.