### PR TITLE
fix: replace newlines with spaces in writer

### DIFF
--- a/lua/symbols-outline/writer.lua
+++ b/lua/symbols-outline/writer.lua
@@ -17,6 +17,12 @@ function M.write_outline(bufnr, lines)
   if not is_buffer_outline(bufnr) then
     return
   end
+
+  lines = vim.tbl_map(function(line)
+    lines, _ = string.gsub(line, "\n", " ")
+    return lines
+  end, lines)
+
   vim.api.nvim_buf_set_option(bufnr, 'modifiable', true)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   vim.api.nvim_buf_set_option(bufnr, 'modifiable', false)


### PR DESCRIPTION
`nvim_buf_set_lines` does not allow newline characters in the individual lines. This change replaces all newline characters in each line with a space character. As far as I know, this only affects the TexLab lsp, since it reports the whole caption of figures, tables, etc. including potential newline characters. There is a case to be made to move this to `parser.get_lines`. This fixes #184.