### PR TITLE
fix(folding): optimize fold/unfold all

### DIFF
--- a/lua/symbols-outline.lua
+++ b/lua/symbols-outline.lua
@@ -145,12 +145,15 @@ function M._set_folded(folded, move_cursor, node_index)
 end
 
 function M._set_all_folded(folded, nodes)
-  nodes = nodes or M.state.outline_items
+  local stack = { nodes or M.state.outline_items }
 
-  for _, node in ipairs(nodes) do
-    node.folded = folded
-    if node.children then
-      M._set_all_folded(folded, node.children)
+  while #stack > 0 do
+    local current_nodes = table.remove(stack, #stack)
+    for _, node in ipairs(current_nodes) do
+      node.folded = folded
+      if node.children then
+        stack[#stack + 1] = node.children
+      end
     end
   end
 


### PR DESCRIPTION
The previous recursive function repeatedly calls `_update_lines()` which is expensive. This makes my nvim freeze up even when working with smaller files; it's a terrible experience with larger files with a lot of symbol.

Changed it to an iterative algorithm and calling `_update_lines()` once at the end after the nodes have been updated. It should help with the memory usage too since the previous recursion wasn't tail call optimized.

fixes https://github.com/simrat39/symbols-outline.nvim/issues/224