### PR TITLE
auto_jump config param

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ local opts = {
   relative_width = true,
   width = 25,
   auto_close = false,
+  auto_jump = false,
   show_numbers = false,
   show_relative_numbers = false,
   show_symbol_details = true,
@@ -104,6 +105,7 @@ local opts = {
 | relative_width         | Whether width of window is set relative to existing windows                    | boolean            | true                     |
 | width                  | Width of window (as a % or columns based on `relative_width`)                  | int                | 25                       |
 | auto_close             | Whether to automatically close the window after selection                      | boolean            | false                    |
+| auto_jump              | Whether to automatically jump to the symbol in the source window               | boolean            | false                    |
 | auto_preview           | Show a preview of the code on hover                                            | boolean            | false                    |
 | show_numbers           | Shows numbers with the outline                                                 | boolean            | false                    |
 | show_relative_numbers  | Shows relative numbers with the outline                                        | boolean            | false                    |

--- a/doc/symbols-outline.txt
+++ b/doc/symbols-outline.txt
@@ -61,6 +61,7 @@ Pass a table to the setup call above with your configuration options.
       relative_width = true,
       width = 25,
       auto_close = false,
+      auto_jump = false,
       show_numbers = false,
       show_relative_numbers = false,
       show_symbol_details = true,
@@ -126,6 +127,7 @@ Pass a table to the setup call above with your configuration options.
 │relative_width        │Whether width of window is set relative to existing windows                  │boolean           │true                  │
 │width                 │Width of window (as a % or columns based on relative_width)                  │int               │25                    │
 │auto_close            │Whether to automatically close the window after selection                    │boolean           │false                 │
+|auto_jump              | Whether to automatically jump to the symbol in the source window               | boolean            | false                    |
 │auto_preview          │Show a preview of the code on hover                                          │boolean           │false                 │
 │show_numbers          │Shows numbers with the outline                                               │boolean           │false                 │
 │show_relative_numbers │Shows relative numbers with the outline                                      │boolean           │false                 │

--- a/lua/symbols-outline.lua
+++ b/lua/symbols-outline.lua
@@ -39,20 +39,6 @@ local function setup_global_autocmd()
   })
 end
 
-local function setup_buffer_autocmd()
-  if config.options.auto_preview then
-    vim.api.nvim_create_autocmd('CursorHold', {
-      buffer = 0,
-      callback = require('symbols-outline.preview').show,
-    })
-  else
-    vim.api.nvim_create_autocmd('CursorMoved', {
-      buffer = 0,
-      callback = require('symbols-outline.preview').close,
-    })
-  end
-end
-
 -------------------------
 -- STATE
 -------------------------
@@ -115,6 +101,25 @@ local function goto_location(change_focus)
   end
   if config.options.auto_close then
     M.close_outline()
+  end
+end
+
+local function setup_buffer_autocmd()
+  if config.options.auto_preview then
+    vim.api.nvim_create_autocmd('CursorHold', {
+      buffer = 0,
+      callback = require('symbols-outline.preview').show,
+    })
+  else
+    vim.api.nvim_create_autocmd('CursorMoved', {
+      buffer = 0,
+      callback = function()
+        require('symbols-outline.preview').close()
+        if config.options.auto_jump then
+          goto_location(false)
+        end
+      end,
+    })
   end
 end
 

--- a/lua/symbols-outline/config.lua
+++ b/lua/symbols-outline/config.lua
@@ -10,6 +10,7 @@ M.defaults = {
   relative_width = true,
   width = 25,
   auto_close = false,
+  auto_jump = false,
   auto_preview = false,
   show_numbers = false,
   show_relative_numbers = false,


### PR DESCRIPTION
This PR creates an `auto_jump` parameter which will automatically follow code in the source window.

https://github.com/simrat39/symbols-outline.nvim/assets/3304073/0fda7e6a-dce6-4739-86d6-38a1377b4a1a

