### PR TITLE
Open handler checks if view is not already open

### DIFF
--- a/lua/symbols-outline.lua
+++ b/lua/symbols-outline.lua
@@ -276,7 +276,7 @@ local function setup_keymaps(bufnr)
 end
 
 local function handler(response)
-  if response == nil or type(response) ~= 'table' then
+  if response == nil or type(response) ~= 'table' or M.view:is_open() then
     return
   end
 


### PR DESCRIPTION
I sometimes get a weird error that says "failed to rename buffer" and then symbols-outline opens multiple windows and runs into a bad state. I reproduced it a few times when I pressed the keybinding to open before the LSP is ready and then the handler gets called multiple times. After this change and spamming the keybinding I can no longer reproduce this issue symbols-outline. 

I don't know if that's sufficient detail to accept this change and whether you will be able to reproduce this edge case but according to the handler implementation it seems like it's always a bad idea to call it when the outline is already open and even without reproduction it makes sense to check it rather than get into this bad state.